### PR TITLE
fix: replace missing testimonial include with card macro

### DIFF
--- a/templates/app/components/content/section_featured_testimonials/index.twig
+++ b/templates/app/components/content/section_featured_testimonials/index.twig
@@ -5,6 +5,7 @@
 {% import "@Elements/_macro-badge.twig" as badges %}
 {% import "@Elements/_macro-image-object.twig" as images %}
 {% import "@Elements/_macro-button.twig" as buttons %}
+{% import "@Elements/_macro-card.twig" as cards %}
 
 {% set component = component.content[0] %}
 
@@ -32,7 +33,14 @@
                 {% set position = testimonial.meta('position') %}
 
                 <div id="testimonial-item-{{ loop.index }}" class="inview-item">
-                    {% include "@Components/cards/testimonials/_component-card-testimonial-boxed.twig" %}
+                    {{ cards.testimonial_card({
+                        id: 'testimonial-' ~ loop.index,
+                        content: quote,
+                        title: name,
+                        meta: {
+                            position: position,
+                        },
+                    }) }}
                 </div>
             {% endfor %}
 		</div>


### PR DESCRIPTION
This fixes a runtime Twig error in the Featured Testimonials section.

Replaces a legacy include to a missing template (@Components/cards/testimonials/_component-card-testimonial-boxed.twig)
Uses the existing unified card macro ([_macro-card.twig](vscode-file://vscode-app/c:/Users/Superuser/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → cards.testimonial_card)
Preserves existing testimonial data mapping (name, quote, position)

Why
Pages using this section could throw a Twig LoaderError and return HTTP 500 when the legacy include path is unavailable.

Impact
Low-risk, one-file template change; no database/schema/config changes.